### PR TITLE
MAINT: Fix doc build

### DIFF
--- a/doc/source/_templates/class.rst
+++ b/doc/source/_templates/class.rst
@@ -12,9 +12,7 @@
    .. autosummary::
       :toctree:
    {% for item in methods %}
-      {% if item != "__init__" %}
-      {{ name }}.{{ item }}
-      {% endif %}
+      ~{{ name }}.{{ item }}
    {%- endfor %}
    {% endif %}
    {% endblock %}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,14 +31,13 @@ extensions = [
 
 # Intersphinx mapping
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/dev", None),
-    # kept here as an example
-    # "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
-    # "numpy": ("https://numpy.org/devdocs", None),
-    # "matplotlib": ("https://matplotlib.org/stable", None),
-    # "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
-    # "pyvista": ("https://docs.pyvista.org/", None),
-    # "grpc": ("https://grpc.github.io/grpc/python/", None),
+    "python": ("https://docs.python.org/3", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "numpy": ("https://numpy.org/devdocs", None),
+    "matplotlib": ("https://matplotlib.org/stable", None),
+    "imageio": ("https://imageio.readthedocs.io/en/stable", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
+    "pytest": ("https://docs.pytest.org/en/stable", None),
 }
 
 # numpydoc configuration
@@ -93,7 +92,7 @@ exclude_patterns = ["_build"]
 # -- Sphinx Gallery Options ---------------------------------------------------
 sphinx_gallery_conf = {
     # convert rst to md for ipynb
-    "pypandoc": True,
+    # "pypandoc": True,
     # path to your examples scripts
     "examples_dirs": ["../../examples/"],
     # path where to save gallery generated examples


### PR DESCRIPTION
- [x] Include __init__ functions to toc tree to get rid of doc build warnings
- [x] Disabled usage of pypandoc to get rid of doc build warnings
- [x] Extended intersphinx_mapping